### PR TITLE
Fix for attribute error caused by updated version of Bokeh (2.3.2) 

### DIFF
--- a/bokeh_app/scripts/density.py
+++ b/bokeh_app/scripts/density.py
@@ -116,7 +116,7 @@ def density_tab(flights):
 	available_carriers.sort()
 
 	airline_colors = Category20_16
-	airline_colors.sort()
+	airline_colors = sorted(airline_colors)
 
 	# Carriers to plot
 	carrier_selection = CheckboxGroup(labels=available_carriers, 

--- a/bokeh_app/scripts/draw_map.py
+++ b/bokeh_app/scripts/draw_map.py
@@ -183,7 +183,7 @@ def map_tab(map_data, states):
 	available_carriers.sort()
 
 	airline_colors = Category20_16
-	airline_colors.sort()
+	airline_colors = sorted(airline_colors)
 
 	# Remove Alaska and Hawaii from states
 	if 'HI' in states: del states['HI']

--- a/bokeh_app/scripts/histogram.py
+++ b/bokeh_app/scripts/histogram.py
@@ -122,7 +122,7 @@ def histogram_tab(flights):
 
 
 	airline_colors = Category20_16
-	airline_colors.sort()
+	airline_colors = sorted(airline_colors)
 		
 	carrier_selection = CheckboxGroup(labels=available_carriers, 
 									  active = [0, 1])


### PR DESCRIPTION
I updated three files in Scripts: density, draw_map, and histogram .  Replaced airline_colors.sort() with airline_colors = sorted(airline_colors) in each file. This resolves error:  "AttributeError: 'tuple' object has no attribute 'sort'"
